### PR TITLE
feat: add password-manager-service plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,6 +23,7 @@ apps:
     plugs:
       - network-status
       - network
+      - password-manager-service
 
 parts:
   libspelling:


### PR DESCRIPTION
In issue https://github.com/GeopJr/Tuba/issues/1414, it was reported that the snap package couldn't access to gnome-keyring on ubuntu 25.04.

Indeed the lack of password-manager-service plug would prevent tuba to access the keyring because of apparmor, outputing this error:

	(dev.geopjr.Tuba:4906): Tuba-CRITICAL **: 01:43:20.930: SecretAccountStore.vala:46: Error while searching for items in the secret service: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender=":1.45" (uid=1000 pid=4906 comm="/snap/tuba/17/usr/bin/dev.geopjr.Tuba" label="snap.tuba.tuba (enforce)") interface="org.freedesktop.Secret.Service" member="SearchItems" error name="(unset)" requested_reply="0" destination=":1.8" (uid=1000 pid=4150 comm="/usr/bin/gnome-keyring-daemon --foreground --compo" label="unconfined")

This patch fixes the issue by providing the password-manager-service plug. However it should be connected manually with `snap connect tuba:password-manager-service`

fix: https://github.com/GeopJr/Tuba/issues/1414